### PR TITLE
Fix pkgconfig file location

### DIFF
--- a/src/QZXing.pri
+++ b/src/QZXing.pri
@@ -320,9 +320,9 @@ symbian {
 
 	# pkg-config support
 	CONFIG += create_pc create_prl no_install_prl
-	QMAKE_PKGCONFIG_DESTDIR = pkgconfig
-	QMAKE_PKGCONFIG_LIBDIR = ${prefix}/lib
-	QMAKE_PKGCONFIG_INCDIR = ${prefix}/include
+	QMAKE_PKGCONFIG_DESTDIR = $$PREFIX/lib/pkgconfig
+	QMAKE_PKGCONFIG_LIBDIR = $$PREFIX/lib
+	QMAKE_PKGCONFIG_INCDIR = $$PREFIX/include
 
 	unix:QMAKE_CLEAN += -r pkgconfig lib$${TARGET}.prl
 }


### PR DESCRIPTION
QMake was installing the pkgconfig file into a non-existent location.